### PR TITLE
Implement TCP server

### DIFF
--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -304,7 +304,7 @@ impl ByteBuffer for ExtendingBuffer {
     }
 
     fn set(&mut self, offset: usize, data: u8) -> Result<()> {
-        if self.head() >= self.buf.len() {
+        if offset >= self.buf.len() {
             return Err(Error::new(ErrorKind::InvalidInput, "Attempted write beyond buffer"));
         }
 

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -6,12 +6,12 @@ const MAX_UDP_SIZE: usize = 512;
 const MAX_LABEL_LEN: usize = 63;
 
 pub trait ByteBuffer {
-    const MAX_SIZE: Option<usize>;
+    const MAX_SIZE: usize;
 
     // Get current position of the cursor in the buffer.
     fn head(&self) -> usize;
 
-    fn max_size(&self) -> Option<usize> {
+    fn max_size(&self) -> usize {
         Self::MAX_SIZE
     }
 
@@ -184,7 +184,7 @@ impl BytePacketBuffer {
 }
 
 impl ByteBuffer for BytePacketBuffer {
-    const MAX_SIZE: Option<usize> = Some(MAX_UDP_SIZE);
+    const MAX_SIZE: usize = MAX_UDP_SIZE;
 
     fn head(&self) -> usize {
         self.head
@@ -203,7 +203,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn read(&mut self) -> Result<u8> {
-        if self.head >= MAX_UDP_SIZE {
+        if self.head >= self.max_size() {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
         let data = self.buf[self.head];
@@ -213,7 +213,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn get(&self, offset: usize) -> Result<u8> {
-        if offset >= MAX_UDP_SIZE {
+        if offset >= self.max_size() {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
 
@@ -221,7 +221,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn get_range(&self, start: usize, len: usize) -> Result<&[u8]> {
-        if start + len >= MAX_UDP_SIZE {
+        if start + len >= self.max_size() {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
 
@@ -229,7 +229,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn write(&mut self, val: u8) -> Result<()> {
-        if self.head() >= MAX_UDP_SIZE {
+        if self.head() >= self.max_size() {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
         self.buf[self.head()] = val;
@@ -260,7 +260,7 @@ impl ExtendingBuffer {
 }
 
 impl ByteBuffer for ExtendingBuffer {
-    const MAX_SIZE: Option<usize> = None;
+    const MAX_SIZE: usize = usize::max_value();
 
     fn head(&self) -> usize {
         self.head

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -1,7 +1,7 @@
 use std::io::{Error, ErrorKind, Result};
 
 // Maximum size of DNS packet
-const MAX_SIZE: usize = 512;
+const MAX_UDP_SIZE: usize = 512;
 // Maximum size of label
 const MAX_LABEL_LEN: usize = 63;
 
@@ -163,7 +163,7 @@ pub trait ByteBuffer {
 }
 
 pub struct BytePacketBuffer {
-    pub buf: [u8; MAX_SIZE], // buffer data
+    pub buf: [u8; MAX_UDP_SIZE], // buffer data
     pub head: usize,         // byte-offset in packet
 }
 
@@ -171,7 +171,7 @@ impl BytePacketBuffer {
     // Fresh buffer
     pub fn new() -> BytePacketBuffer {
         BytePacketBuffer {
-            buf: [0; MAX_SIZE],
+            buf: [0; MAX_UDP_SIZE],
             head: 0,
         }
     }
@@ -196,7 +196,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn read(&mut self) -> Result<u8> {
-        if self.head >= MAX_SIZE {
+        if self.head >= MAX_UDP_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
         let data = self.buf[self.head];
@@ -206,7 +206,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn get(&self, offset: usize) -> Result<u8> {
-        if offset >= MAX_SIZE {
+        if offset >= MAX_UDP_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
 
@@ -214,7 +214,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn get_range(&self, start: usize, len: usize) -> Result<&[u8]> {
-        if start + len >= MAX_SIZE {
+        if start + len >= MAX_UDP_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
 
@@ -222,7 +222,7 @@ impl ByteBuffer for BytePacketBuffer {
     }
 
     fn write(&mut self, val: u8) -> Result<()> {
-        if self.head() >= MAX_SIZE {
+        if self.head() >= MAX_UDP_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
         self.buf[self.head()] = val;
@@ -246,7 +246,7 @@ pub struct ExtendingBuffer {
 impl ExtendingBuffer {
     pub fn new() -> ExtendingBuffer {
         ExtendingBuffer {
-            buf: Vec::with_capacity(MAX_SIZE),  // TODO: decide sane capacity for performance
+            buf: Vec::with_capacity(MAX_UDP_SIZE),  // TODO: decide sane capacity for performance
             head: 0
         }
     }

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -6,8 +6,14 @@ const MAX_UDP_SIZE: usize = 512;
 const MAX_LABEL_LEN: usize = 63;
 
 pub trait ByteBuffer {
+    const MAX_SIZE: Option<usize>;
+
     // Get current position of the cursor in the buffer.
     fn head(&self) -> usize;
+
+    fn max_size(&self) -> Option<usize> {
+        Self::MAX_SIZE
+    }
 
     // Manipulating head of buffer
 
@@ -178,6 +184,7 @@ impl BytePacketBuffer {
 }
 
 impl ByteBuffer for BytePacketBuffer {
+    const MAX_SIZE: Option<usize> = Some(MAX_UDP_SIZE);
 
     fn head(&self) -> usize {
         self.head
@@ -253,6 +260,8 @@ impl ExtendingBuffer {
 }
 
 impl ByteBuffer for ExtendingBuffer {
+    const MAX_SIZE: Option<usize> = None;
+
     fn head(&self) -> usize {
         self.head
     }

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -5,6 +5,163 @@ const MAX_SIZE: usize = 512;
 // Maximum size of label
 const MAX_LABEL_LEN: usize = 63;
 
+pub trait ByteBuffer {
+    // Get current position of the cursor in the buffer.
+    fn head(&self) -> usize;
+
+    // Manipulating head of buffer
+
+    fn step(&mut self, steps: usize) -> Result<()>;
+
+    fn seek(&mut self, offset: usize) -> Result<()>;
+
+    // Basic reading from buffer
+
+    fn read(&mut self) -> Result<u8>;
+
+    fn read_u16(&mut self) -> Result<u16> {
+        let data = (self.read()? as u16) << 8 | self.read()? as u16;
+
+        Ok(data)
+    }
+
+    fn read_u32(&mut self) -> Result<u32> {
+        let data = (self.read_u16()? as u32) << 16 | self.read_u16()? as u32;
+
+        Ok(data)
+    }
+
+    // Basic writing to buffer
+
+    fn write(&mut self, data: u8) -> Result<()>;
+
+    fn write_u16(&mut self, data: u16) -> Result<()> {
+        // Write high byte
+        self.write((data >> 8) as u8)?;
+        // Write low byte
+        self.write((data & 0xFF) as u8)?;
+
+        Ok(())
+    }
+
+    fn write_u32(&mut self, data: u32) -> Result<()> {
+        // Write two high bytes
+        self.write_u16((data >> 16) as u16)?;
+        // Write two low bytes
+        self.write_u16((data & 0xFFFF) as u16)?;
+
+        Ok(())
+    }
+
+    // Reading from buffer without mutating buffer's head
+
+    fn get(&self, offset: usize) -> Result<u8>;
+
+    fn get_range(&self, offset: usize, len: usize) -> Result<&[u8]>;
+
+    // Writing to buffer without mutating buffer's head
+
+    fn set(&mut self, offset: usize, data: u8) -> Result<()>;
+
+    fn set_u16(&mut self, offset: usize, data: u16) -> Result<()> {
+        // Set high byte
+        self.set(offset, (data >> 8) as u8)?;
+        // Set low byte
+        self.set(offset + 1, (data & 0xFF) as u8)?;
+
+        Ok(())
+    }
+
+    // Methods for interacting with domain names
+
+    fn read_qname(&mut self, qname: &mut String) -> Result<()> {
+        // To handle jumps keep track of head offset locally
+        let mut pos = self.head();
+
+        // track whether we've encountered a jump
+        let mut jumped = false;
+
+        // Delimiter between labels in name. For first iteration, keep empty.
+        // Next iterations will use '.'
+        let mut delim = "";
+        loop {
+            // Beginning of label, so grab length byte
+            let label_len = self.get(pos)?;
+
+            // If two most significant bits are set, we need to jump
+            if (label_len & 0xC0) == 0xC0 {
+                // Move the head past the length byte and jump byte
+                if !jumped {
+                    self.seek(pos + 2)?;
+                }
+
+                // Read another byte, calculate offset and jump
+                let jump_byte = self.get(pos + 1)? as u16;
+                let offset = (((label_len as u16) ^ 0xC0) << 8) | jump_byte;
+                pos = offset as usize;
+
+                // We jumped
+                jumped = true;
+            }
+            // No-jump scenario, where a single label is read
+            else {
+                // Move one byte past length byte
+                pos += 1;
+
+                // Domain names are terminated by an empty byte
+                if label_len == 0 {
+                    break;
+                }
+
+                // Apppend delimiter to output buffer
+                qname.push_str(delim);
+
+                // Extract ASCII bytes for the label and append to output buffer
+                let str_buffer = self.get_range(pos, label_len as usize)?;
+                qname.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
+
+                delim = ".";
+
+                // Move forward in packet buffer by length of label
+                pos += label_len as usize;
+            }
+        }
+
+        // If we jumped, no need to change buffer position
+        if !jumped {
+            self.seek(pos)?;
+        }
+
+        Ok(())
+    }
+
+    fn write_qname(&mut self, qname: &str) -> Result<()> {
+        let labels = qname.split('.').collect::<Vec<&str>>();
+
+        for label in labels {
+            // Check label length
+            let len = label.len();
+            if len > MAX_LABEL_LEN {
+                return Err(Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("Label exceeds maximum length: {0}", MAX_LABEL_LEN),
+                ));
+            }
+
+            // Write the length of the label and then the label
+            self.write(len as u8)?;
+            for label_byte in label.as_bytes() {
+                self.write(*label_byte)?;
+            }
+        }
+
+        // Write null byte to terminate qname
+        self.write(0)?;
+
+        Ok(())
+    }
+}
+
 pub struct BytePacketBuffer {
     pub buf: [u8; MAX_SIZE], // buffer data
     pub head: usize,         // byte-offset in packet

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -175,27 +175,27 @@ impl BytePacketBuffer {
             head: 0,
         }
     }
+}
 
-    pub fn head(&self) -> usize {
+impl ByteBuffer for BytePacketBuffer {
+
+    fn head(&self) -> usize {
         self.head
     }
 
-    // Move head along buffer
-    pub fn step(&mut self, steps: usize) -> Result<()> {
+    fn step(&mut self, steps: usize) -> Result<()> {
         self.head += steps;
 
         Ok(())
     }
 
-    // Seek the buffer head to some offset
     fn seek(&mut self, offset: usize) -> Result<()> {
         self.head = offset;
 
         Ok(())
     }
 
-    // Read single byte and move along buffer
-    pub fn read(&mut self) -> Result<u8> {
+    fn read(&mut self) -> Result<u8> {
         if self.head >= MAX_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
@@ -205,23 +205,6 @@ impl BytePacketBuffer {
         Ok(data)
     }
 
-    pub fn read_u16(&mut self) -> Result<u16> {
-        let data = (self.read()? as u16) << 8 | self.read()? as u16;
-
-        Ok(data)
-    }
-
-    pub fn read_u32(&mut self) -> Result<u32> {
-        let data = (self.read()? as u32) << 24
-            | (self.read()? as u32) << 16
-            | (self.read()? as u32) << 8
-            | (self.read()? as u32);
-
-        Ok(data)
-    }
-
-    // Methods for reading data from buffer without mutating buffer state
-
     fn get(&self, offset: usize) -> Result<u8> {
         if offset >= MAX_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
@@ -230,73 +213,12 @@ impl BytePacketBuffer {
         Ok(self.buf[offset])
     }
 
-    pub fn get_range(&self, start: usize, len: usize) -> Result<&[u8]> {
+    fn get_range(&self, start: usize, len: usize) -> Result<&[u8]> {
         if start + len >= MAX_SIZE {
             return Err(Error::new(ErrorKind::InvalidInput, "End of buffer"));
         }
 
         Ok(&self.buf[start..start + len])
-    }
-
-    pub fn read_qname(&mut self, outstr: &mut String) -> Result<()> {
-        // To handle jumps keep track of head offset locally
-        let mut pos = self.head();
-
-        // track whether we've encountered a jump
-        let mut jumped = false;
-
-        // Delimiter between labels in name. For first iteration, keep empty.
-        // Next iterations will use '.'
-        let mut delim = "";
-        loop {
-            // Beginning of label, so grab length byte
-            let len = self.get(pos)?;
-
-            // If two most significant bytes are set, we need to jump
-            if (len & 0xC0) == 0xC0 {
-                // Move the head past the label since it contains no additional information
-                if !jumped {
-                    self.seek(pos + 2)?;
-                }
-
-                // Read another byte, calculate offset and jump
-                let jump_byte = self.get(pos + 1)? as u16;
-                let offset = (((len as u16) ^ 0xC0) << 8) | jump_byte;
-                pos = offset as usize;
-
-                // We jumped
-                jumped = true;
-            }
-            // No-jump scenario, where a single label is read
-            else {
-                // Move one byte past length byte
-                pos += 1;
-
-                // Domain names are terminated by an empty label
-                if len == 0 {
-                    break;
-                }
-
-                // Apppend delimiter to output buffer
-                outstr.push_str(delim);
-
-                // Extract ASCII bytes for the label and append to output buffer
-                let str_buffer = self.get_range(pos, len as usize)?;
-                outstr.push_str(&String::from_utf8_lossy(str_buffer).to_lowercase());
-
-                delim = ".";
-
-                // Move forward in packet buffer by length of label
-                pos += len as usize;
-            }
-        }
-
-        // If we jumped, no need to change buffer position
-        if !jumped {
-            self.seek(pos)?;
-        }
-
-        Ok(())
     }
 
     fn write(&mut self, val: u8) -> Result<()> {
@@ -309,66 +231,8 @@ impl BytePacketBuffer {
         Ok(())
     }
 
-    pub fn write_u8(&mut self, val: u8) -> Result<()> {
-        self.write(val)?;
-
-        Ok(())
-    }
-
-    pub fn write_u16(&mut self, val: u16) -> Result<()> {
-        self.write((val >> 8) as u8)?;
-        self.write((val & 0xFF) as u8)?;
-
-        Ok(())
-    }
-
-    pub fn write_u32(&mut self, val: u32) -> Result<()> {
-        let mask = 0xFF;
-        self.write(((val >> 24) & mask) as u8)?;
-        self.write(((val >> 16) & mask) as u8)?;
-        self.write(((val >> 8) & mask) as u8)?;
-        self.write(((val >> 0) & mask) as u8)?;
-
-        Ok(())
-    }
-
-    pub fn write_qname(&mut self, qname: &str) -> Result<()> {
-        let labels = qname.split('.').collect::<Vec<&str>>();
-
-        for label in labels {
-            // Check label length
-            let len = label.len();
-            if len > MAX_LABEL_LEN {
-                return Err(Error::new(
-                    ErrorKind::InvalidInput,
-                    format!("Label exceeds maximum length: {0}", MAX_LABEL_LEN),
-                ));
-            }
-
-            // Write the length of the label and then the label
-            self.write_u8(len as u8)?;
-            for label_byte in label.as_bytes() {
-                self.write_u8(*label_byte)?;
-            }
-        }
-
-        // Write null byte to terminate qname
-        self.write_u8(0)?;
-
-        Ok(())
-    }
-
-    // Method for setting buffer values
-
-    pub fn set(&mut self, pos: usize, val: u8) -> Result<()> {
+    fn set(&mut self, pos: usize, val: u8) -> Result<()> {
         self.buf[pos] = val;
-
-        Ok(())
-    }
-
-    pub fn set_u16(&mut self, pos: usize, val: u16) -> Result<()> {
-        self.set(pos, (val >> 8) as u8)?;
-        self.set(pos + 1, (val & 0xFF) as u8)?;
 
         Ok(())
     }

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -244,7 +244,7 @@ pub struct ExtendingBuffer {
 }
 
 impl ExtendingBuffer {
-    fn new() -> ExtendingBuffer {
+    pub fn new() -> ExtendingBuffer {
         ExtendingBuffer {
             buf: Vec::with_capacity(MAX_SIZE),  // TODO: decide sane capacity for performance
             head: 0

--- a/src/dns/buffer.rs
+++ b/src/dns/buffer.rs
@@ -303,11 +303,11 @@ impl ByteBuffer for ExtendingBuffer {
     }
 
     fn get_range(&self, offset: usize, len: usize) -> Result<&[u8]> {
-        if offset + len >= self.buf.len() {
+        if offset + len > self.buf.len() {
             return Err(Error::new(ErrorKind::InvalidInput, "Attempted read beyond buffer"));
         }
 
-        let data = &self.buf[offset..len];
+        let data = &self.buf[offset..offset + len];
 
         Ok(data)
     }

--- a/src/dns/network.rs
+++ b/src/dns/network.rs
@@ -1,7 +1,7 @@
-use super::buffer::{BytePacketBuffer, ByteBuffer};
+use super::buffer::{ByteBuffer, BytePacketBuffer, ExtendingBuffer, VariableBuffer};
 use super::protocol::{DnsPacket, DnsQuestion, QueryType};
-use std::io::{Error, ErrorKind, Result};
-use std::net::UdpSocket;
+use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::net::{TcpStream, UdpSocket};
 use std::sync::atomic::{AtomicU16, Ordering};
 
 pub struct NetworkClient {
@@ -24,8 +24,35 @@ impl NetworkClient {
         server: (&str, u16),
         recursive: bool,
     ) -> Result<DnsPacket> {
-        println!("Would query {} over TCP", qname);
-        unimplemented!();
+        // Set up connection to downstream server
+        let mut stream = TcpStream::connect(&server)?;
+
+        // Prepare question packet to send downstream
+        let mut packet = DnsPacket::new();
+        packet.header.id = self.pid_seq.fetch_add(1, Ordering::SeqCst);
+        packet.header.questions = 1;
+        packet.header.recursion_desired = recursive;
+        packet
+            .questions
+            .push(DnsQuestion::new(String::from(qname), qtype));
+
+        // Write question into buffer and send request
+        let mut req_buffer = BytePacketBuffer::new();
+        let data_len = packet.write(&mut req_buffer).unwrap();
+        let mut len_buffer = [0; 2];
+        len_buffer[0] = (data_len >> 8) as u8;
+        len_buffer[1] = (data_len & 0xFF) as u8;
+        stream.write(&len_buffer)?;
+        stream.write(&req_buffer.buf[0..req_buffer.head()])?;
+
+        // Read the response
+        let mut len_buffer = [0; 2];
+        stream.read(&mut len_buffer)?;
+        let buf_len = ((len_buffer[0] as u16) << 8) | (len_buffer[1] as u16);
+        let mut res_buffer = VariableBuffer::new(buf_len as usize);
+        stream.read(&mut res_buffer.buf).unwrap();
+
+        DnsPacket::from_buffer(&mut res_buffer)
     }
 
     fn send_udp_query(

--- a/src/dns/network.rs
+++ b/src/dns/network.rs
@@ -1,4 +1,4 @@
-use super::buffer::BytePacketBuffer;
+use super::buffer::{BytePacketBuffer, ByteBuffer};
 use super::protocol::{DnsPacket, DnsQuestion, QueryType};
 use std::io::{Error, ErrorKind, Result};
 use std::net::UdpSocket;

--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -107,7 +107,7 @@ impl DnsHeader {
         }
     }
 
-    pub fn read(&mut self, buffer: &mut BytePacketBuffer) -> Result<()> {
+    pub fn read<T: ByteBuffer>(&mut self, buffer: &mut T) -> Result<()> {
         // Packet ID
         self.id = buffer.read_u16()?;
 
@@ -137,7 +137,7 @@ impl DnsHeader {
         Ok(())
     }
 
-    pub fn write(&self, buffer: &mut BytePacketBuffer) -> Result<()> {
+    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<()> {
         // Write packet ID
         buffer.write_u16(self.id)?;
 
@@ -180,7 +180,7 @@ impl DnsQuestion {
         DnsQuestion { name, qtype }
     }
 
-    pub fn read(&mut self, buffer: &mut BytePacketBuffer) -> Result<()> {
+    pub fn read<T: ByteBuffer>(&mut self, buffer: &mut T) -> Result<()> {
         // Query name
         buffer.read_qname(&mut self.name)?;
         // Query type
@@ -191,7 +191,7 @@ impl DnsQuestion {
         Ok(())
     }
 
-    pub fn write(&self, buffer: &mut BytePacketBuffer) -> Result<()> {
+    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<()> {
         buffer.write_qname(&self.name)?;
 
         let qtype = self.qtype.to_num();
@@ -240,7 +240,7 @@ pub enum DnsRecord {
 }
 
 impl DnsRecord {
-    pub fn read(buffer: &mut BytePacketBuffer) -> Result<DnsRecord> {
+    pub fn read<T: ByteBuffer>(buffer: &mut T) -> Result<DnsRecord> {
         let mut domain = String::new();
         buffer.read_qname(&mut domain)?;
 
@@ -319,7 +319,7 @@ impl DnsRecord {
         }
     }
 
-    pub fn write(&self, buffer: &mut BytePacketBuffer) -> Result<usize> {
+    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<usize> {
         let start_pos = buffer.head();
 
         match *self {
@@ -446,7 +446,7 @@ impl DnsPacket {
         }
     }
 
-    pub fn from_buffer(buffer: &mut BytePacketBuffer) -> Result<DnsPacket> {
+    pub fn from_buffer<T: ByteBuffer>(buffer: &mut T) -> Result<DnsPacket> {
         // Read in header
         let mut result = DnsPacket::new();
         result.header.read(buffer)?;
@@ -480,7 +480,7 @@ impl DnsPacket {
         Ok(result)
     }
 
-    pub fn write(&mut self, buffer: &mut BytePacketBuffer) -> Result<()> {
+    pub fn write<T: ByteBuffer>(&mut self, buffer: &mut T) -> Result<()> {
         // Setup temporary buffer in case this message gets truncated
         let mut temp_buf = BytePacketBuffer::new();
 

--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -137,7 +137,9 @@ impl DnsHeader {
         Ok(())
     }
 
-    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<()> {
+    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<usize> {
+        let start_pos = buffer.head();
+
         // Write packet ID
         buffer.write_u16(self.id)?;
 
@@ -165,7 +167,7 @@ impl DnsHeader {
         buffer.write_u16(self.authoritative_entries)?;
         buffer.write_u16(self.resource_entries)?;
 
-        Ok(())
+        Ok(buffer.head() - start_pos)
     }
 }
 
@@ -191,14 +193,16 @@ impl DnsQuestion {
         Ok(())
     }
 
-    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<()> {
+    pub fn write<T: ByteBuffer>(&self, buffer: &mut T) -> Result<usize> {
+        let start_pos = buffer.head();
+
         buffer.write_qname(&self.name)?;
 
         let qtype = self.qtype.to_num();
         buffer.write_u16(qtype)?;
         buffer.write_u16(1)?; // class
 
-        Ok(())
+        Ok(buffer.head() - start_pos)
     }
 }
 

--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -142,7 +142,7 @@ impl DnsHeader {
         buffer.write_u16(self.id)?;
 
         // Write first byte's-worth of flags
-        buffer.write_u8(
+        buffer.write(
             ((self.response as u8) << 7)
                 | (self.opcode << 6)
                 | ((self.authoritative_answer as u8) << 2)
@@ -151,7 +151,7 @@ impl DnsHeader {
         )?;
 
         // Write the next byte's-worth of flags
-        buffer.write_u8(
+        buffer.write(
             ((self.recursion_available as u8) << 7)
                 | ((self.z as u8) << 6)
                 | ((self.authed_data as u8) << 5)
@@ -337,7 +337,7 @@ impl DnsRecord {
                 // Write IP address
                 let octets = addr.octets();
                 for o in octets.iter() {
-                    buffer.write_u8(*o)?;
+                    buffer.write(*o)?;
                 }
             }
             DnsRecord::NS {

--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -291,6 +291,7 @@ impl DnsRecord {
             }
             QueryType::NS => {
                 let mut host = String::new();
+                buffer.read_qname(&mut host)?;
                 Ok(DnsRecord::NS { domain, host, ttl })
             }
             QueryType::MX => {

--- a/src/dns/protocol.rs
+++ b/src/dns/protocol.rs
@@ -489,7 +489,7 @@ impl DnsPacket {
 
         // Setup temporary buffer in case this message gets truncated
         let mut temp_buf = ExtendingBuffer::new();
-        let max_size = buffer.max_size().unwrap_or(usize::max_value());
+        let max_size = buffer.max_size();
         let mut size = 0;
 
         // We should have enough space so far to write the header and questions

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -2,7 +2,7 @@ use super::buffer::*;
 use super::context::ServerContext;
 use super::protocol::*;
 use std::boxed::Box;
-use std::io::{Result, Read};
+use std::io::{Result, Read, Write};
 use std::net::{UdpSocket, TcpListener};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
@@ -237,20 +237,73 @@ impl DnsServer for TcpServer {
         let context_ptr = self.context.clone();
 
         let tcp_thread = thread::Builder::new().name("DNS - TCP server worker".to_string()).spawn(move || {
-            let context_clone = context_ptr.clone();
             for stream in listener.incoming() {
+                let thread_context = context_ptr.clone();
                 match stream {
                     Ok(mut stream) => {
                         thread_pool.execute(move || {
-                            let mut req_buffer = BytePacketBuffer::new(); // FIXME: use buffer with no length limit
+                            let mut len_buf = [0;2];
+                            stream.read(&mut len_buf).unwrap();
+                            // Read request from stream into buffer
+                            // FIXME: use buffer with no size limit and capacity of length read from stream
+                            let mut req_buffer = BytePacketBuffer::new();
                             match stream.read(&mut req_buffer.buf) {
                                 Ok(bytes_read) => {
-                                    println!("Read {0} bytes from stream", bytes_read);
+                                    println!("Read {} bytes from stream", bytes_read);
                                 },
                                 Err(e) => {
                                     println!("Failed to read bytes from stream: {:?}", e);
+                                    return;
                                 }
                             }
+                            // Parse request buffer into packet
+                            let request = match DnsPacket::from_buffer(&mut req_buffer) {
+                                Ok(packet) => packet,
+                                Err(e) => {
+                                    println!("Failed to parse DNS packet: {:?}", e);
+                                    return;
+                                }
+                            };
+                            // Execute the query in the request and write the response into a buffer
+                            let mut response = execute_query(request, thread_context);
+                            let mut res_buffer = ExtendingBuffer::new();
+                            match response.write(&mut res_buffer) {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    println!("Failed to write response packet to buffer: {:?}", e);
+                                    return;
+                                }
+                            }
+
+                            let res_len = res_buffer.head();
+                            let res_data = match res_buffer.get_range(0, res_len) {
+                                Ok(result) => result,
+                                Err(e) => {
+                                    println!("Failed to read response buffer: {:?}", e);
+                                    return;
+                                }
+                            };
+
+                            // Write packet length first
+                            let mut len_buf = [0; 2];
+                            len_buf[0] = (res_len >> 8) as u8;
+                            len_buf[1] = (res_len & 0xFF) as u8;
+                            match stream.write(&len_buf) {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    println!("Failed to write packet length to buffer: {:?}", e);
+                                    return;
+                                }
+                            }
+                            // Now, write the data
+                            match stream.write(res_data) {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    println!("Failed to send response buffer: {:?}", e);
+                                    return;
+                                }
+                            }
+                            
                         });
                     },
                     Err(e) => {

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -134,6 +134,8 @@ pub trait DnsServer {
     fn run(&self, thread_count: usize) -> Result<thread::JoinHandle<()>>;
 }
 
+// UDP server
+
 pub struct UdpServer {
     context: Arc<ServerContext>,
 }
@@ -212,5 +214,23 @@ impl DnsServer for UdpServer {
             })?;
 
         Ok(udp_thread)
+    }
+}
+
+// TCP server
+
+pub struct TcpServer {
+    context: Arc<ServerContext>
+}
+
+impl TcpServer {
+    pub fn new(context: Arc<ServerContext>) -> TcpServer {
+        TcpServer { context }
+    }
+}
+
+impl DnsServer for TcpServer {
+    fn run(&self, thread_count: usize) -> Result<thread::JoinHandle<()>> {
+        unimplemented!();
     }
 }

--- a/src/dns/server.rs
+++ b/src/dns/server.rs
@@ -2,8 +2,8 @@ use super::buffer::*;
 use super::context::ServerContext;
 use super::protocol::*;
 use std::boxed::Box;
-use std::io::{Result, Read, Write};
-use std::net::{UdpSocket, TcpListener};
+use std::io::{Read, Result, Write};
+use std::net::{TcpListener, UdpSocket};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread;
 
@@ -220,7 +220,7 @@ impl DnsServer for UdpServer {
 // TCP server
 
 pub struct TcpServer {
-    context: Arc<ServerContext>
+    context: Arc<ServerContext>,
 }
 
 impl TcpServer {
@@ -236,82 +236,90 @@ impl DnsServer for TcpServer {
         let listener = TcpListener::bind(("0.0.0.0", self.context.dns_port)).unwrap();
         let context_ptr = self.context.clone();
 
-        let tcp_thread = thread::Builder::new().name("DNS - TCP server worker".to_string()).spawn(move || {
-            for stream in listener.incoming() {
-                let thread_context = context_ptr.clone();
-                match stream {
-                    Ok(mut stream) => {
-                        thread_pool.execute(move || {
-                            let mut len_buf = [0;2];
-                            stream.read(&mut len_buf).unwrap();
-                            // Read request from stream into buffer
-                            // FIXME: use buffer with no size limit and capacity of length read from stream
-                            let mut req_buffer = BytePacketBuffer::new();
-                            match stream.read(&mut req_buffer.buf) {
-                                Ok(bytes_read) => {
-                                    println!("Read {} bytes from stream", bytes_read);
-                                },
-                                Err(e) => {
-                                    println!("Failed to read bytes from stream: {:?}", e);
-                                    return;
+        let tcp_thread = thread::Builder::new()
+            .name("DNS - TCP server worker".to_string())
+            .spawn(move || {
+                for stream in listener.incoming() {
+                    let thread_context = context_ptr.clone();
+                    match stream {
+                        Ok(mut stream) => {
+                            thread_pool.execute(move || {
+                                let mut len_buf = [0; 2];
+                                stream.read(&mut len_buf).unwrap();
+                                // Read request from stream into buffer
+                                // FIXME: use buffer with no size limit and capacity of length read from stream
+                                let buf_len = ((len_buf[0] as u16) << 8) | (len_buf[1] as u16);
+                                let mut req_buffer = VariableBuffer::new(buf_len as usize);
+                                match stream.read(&mut req_buffer.buf) {
+                                    Ok(bytes_read) => {
+                                        println!("Read {} bytes from stream", bytes_read);
+                                    }
+                                    Err(e) => {
+                                        println!("Failed to read bytes from stream: {:?}", e);
+                                        return;
+                                    }
                                 }
-                            }
-                            // Parse request buffer into packet
-                            let request = match DnsPacket::from_buffer(&mut req_buffer) {
-                                Ok(packet) => packet,
-                                Err(e) => {
-                                    println!("Failed to parse DNS packet: {:?}", e);
-                                    return;
+                                // Parse request buffer into packet
+                                let request = match DnsPacket::from_buffer(&mut req_buffer) {
+                                    Ok(packet) => packet,
+                                    Err(e) => {
+                                        println!("Failed to parse DNS packet: {:?}", e);
+                                        return;
+                                    }
+                                };
+                                // Execute the query in the request and write the response into a buffer
+                                let mut response = execute_query(request, thread_context);
+                                let mut res_buffer = ExtendingBuffer::new();
+                                match response.write(&mut res_buffer) {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        println!(
+                                            "Failed to write response packet to buffer: {:?}",
+                                            e
+                                        );
+                                        return;
+                                    }
                                 }
-                            };
-                            // Execute the query in the request and write the response into a buffer
-                            let mut response = execute_query(request, thread_context);
-                            let mut res_buffer = ExtendingBuffer::new();
-                            match response.write(&mut res_buffer) {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    println!("Failed to write response packet to buffer: {:?}", e);
-                                    return;
-                                }
-                            }
 
-                            let res_len = res_buffer.head();
-                            let res_data = match res_buffer.get_range(0, res_len) {
-                                Ok(result) => result,
-                                Err(e) => {
-                                    println!("Failed to read response buffer: {:?}", e);
-                                    return;
-                                }
-                            };
+                                let res_len = res_buffer.head();
+                                let res_data = match res_buffer.get_range(0, res_len) {
+                                    Ok(result) => result,
+                                    Err(e) => {
+                                        println!("Failed to read response buffer: {:?}", e);
+                                        return;
+                                    }
+                                };
 
-                            // Write packet length first
-                            let mut len_buf = [0; 2];
-                            len_buf[0] = (res_len >> 8) as u8;
-                            len_buf[1] = (res_len & 0xFF) as u8;
-                            match stream.write(&len_buf) {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    println!("Failed to write packet length to buffer: {:?}", e);
-                                    return;
+                                // Write packet length first
+                                let mut len_buf = [0; 2];
+                                len_buf[0] = (res_len >> 8) as u8;
+                                len_buf[1] = (res_len & 0xFF) as u8;
+                                match stream.write(&len_buf) {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        println!(
+                                            "Failed to write packet length to buffer: {:?}",
+                                            e
+                                        );
+                                        return;
+                                    }
                                 }
-                            }
-                            // Now, write the data
-                            match stream.write(res_data) {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    println!("Failed to send response buffer: {:?}", e);
-                                    return;
+                                // Now, write the data
+                                match stream.write(res_data) {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        println!("Failed to send response buffer: {:?}", e);
+                                        return;
+                                    }
                                 }
-                            }
-                            
-                        });
-                    },
-                    Err(e) => {
-                        println!("Failed to read TCP stream: {:?}", e);
+                            });
+                        }
+                        Err(e) => {
+                            println!("Failed to read TCP stream: {:?}", e);
+                        }
                     }
                 }
-            }
-        })?;
+            })?;
 
         Ok(tcp_thread)
     }


### PR DESCRIPTION
## Description
Implement TCP DNS server to handle DNS over TCP. This should be used when:
* Response to a client (e.g. long **TXT** records) is too long; server will set the _truncated message_ bit in the response to signal to the client that TCP should be used instead
* Response from downstream server is too long; server will retry the request over TCP

## Miscellaneous changes
* Support for **TXT** records
* Refactoring for buffer structs